### PR TITLE
chore: add infosec badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![scorecard-score](https://github.com/recursionpharma/octo-guard-badges/blob/trunk/badges/repo/bc_code/maturity_score.svg?raw=true)](https://infosec-docs.prod.rxrx.io/octoguard/scorecards/bc_code)
+[![scorecard-status](https://github.com/recursionpharma/octo-guard-badges/blob/trunk/badges/repo/bc_code/scorecard_status.svg?raw=true)](https://infosec-docs.prod.rxrx.io/octoguard/scorecards/bc_code)
+[![team-status](https://github.com/recursionpharma/octo-guard-badges/blob/trunk/badges/team/information-technology/team_status.svg?raw=true)](https://infosec-docs.prod.rxrx.io/octoguard/team-reports/information-technology)
 # Batch Connect - OSC Code Server
 
 ![GitHub Release](https://img.shields.io/github/release/osc/bc_osc_codeserver.svg)


### PR DESCRIPTION
update from `legion` on behalf of @dmaljovec

# What?
 - Ensure Octoguard badges exist on the Github repository
# Why?
 - This should give owners more visibiilty into this project's security posture